### PR TITLE
Uninstall profile and import/upgrade steps improved

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Added correct addview to our portlets.xml, so you can add it.
+  Added upgrade step to replace current portlet type definition.
+  The automatically added portlet works, but you cannot add another one.
+  [maurits]
 
 
 2.1.1 (2016-05-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Replaced import step with post_handler.  [maurits]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Breaking changes:
 
 New features:
 
+- Added uninstall profile.  [maurits]
+
 - Replaced import step with post_handler.  [maurits]
 
 Bug fixes:

--- a/plone/app/openid/configure.zcml
+++ b/plone/app/openid/configure.zcml
@@ -24,6 +24,16 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:upgradeStep
+      zcml:condition="installed openid.yadis"
+      title="Register portlet with correct addview"
+      description="Our portlet may have been registered with an empty string as addview, which means you cannot add it anywhere."
+      source="2.0b2"
+      destination="1000"
+      handler=".setuphandlers.registerPortletAddview"
+      profile="plone.app.openid:default"
+      />
+
    <cmf:registerDirectory name="ploneopenid"/>
 
    <include package=".portlets" />

--- a/plone/app/openid/configure.zcml
+++ b/plone/app/openid/configure.zcml
@@ -19,6 +19,15 @@
       post_handler=".setuphandlers.importVarious"
       />
 
+  <genericsetup:registerProfile
+      zcml:condition="installed openid.yadis"
+      name="uninstall"
+      title="OpenID Authentication Support [uninstall]"
+      directory="profiles/uninstall"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      post_handler=".setuphandlers.uninstall"
+      />
+
   <genericsetup:upgradeStep
       zcml:condition="installed openid.yadis"
       title="Register portlet with correct addview"

--- a/plone/app/openid/configure.zcml
+++ b/plone/app/openid/configure.zcml
@@ -9,12 +9,6 @@
 
   <five:registerPackage package="." />
 
-  <genericsetup:importStep
-      name="ploneopenid-various"
-      title="Set up OpenID authentication in Plone"
-      handler="plone.app.openid.setuphandlers.importVarious"
-      description="Add OpenID authentication support to Plone. This adds a new OpenID login portlet and modifies the login form to add OpenID support." />
-
   <genericsetup:registerProfile
       zcml:condition="installed openid.yadis"
       name="default"
@@ -22,6 +16,7 @@
       description="Adds support for authenticating with OpenID credentials in a Plone site"
       directory="profiles/default"
       provides="Products.GenericSetup.interfaces.EXTENSION"
+      post_handler=".setuphandlers.importVarious"
       />
 
   <genericsetup:upgradeStep

--- a/plone/app/openid/profiles/default/metadata.xml
+++ b/plone/app/openid/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2.0b2</version>
+  <version>1000</version>
 </metadata>

--- a/plone/app/openid/profiles/default/openid-pas.txt
+++ b/plone/app/openid/profiles/default/openid-pas.txt
@@ -1,1 +1,0 @@
-add magic file

--- a/plone/app/openid/profiles/default/portlets.xml
+++ b/plone/app/openid/profiles/default/portlets.xml
@@ -4,6 +4,7 @@
     i18n:domain="plone">
 
  <portlet
+   addview="portlets.OpenIDLogin"
    title="OpenID Login"
    description="A portlet which can render an OpenID log-in box"
    i18n:attributes="title;

--- a/plone/app/openid/profiles/uninstall/metadata.xml
+++ b/plone/app/openid/profiles/uninstall/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1000</version>
+</metadata>

--- a/plone/app/openid/profiles/uninstall/portlets.xml
+++ b/plone/app/openid/profiles/uninstall/portlets.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<portlets>
+  <portlet addview="portlets.OpenIDLogin" remove="true" />
+</portlets>

--- a/plone/app/openid/profiles/uninstall/skins.xml
+++ b/plone/app/openid/profiles/uninstall/skins.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_skins" meta_type="Plone Skins Tool">
+ <object name="ploneopenid" remove="true" />
+  <skin-path name="*">
+    <layer name="ploneopenid" remove="true" />
+  </skin-path>
+</object>

--- a/plone/app/openid/setuphandlers.py
+++ b/plone/app/openid/setuphandlers.py
@@ -3,11 +3,20 @@ from plone.app.openid.portlets.login import Assignment as LoginAssignment
 from plone.openid.plugins.oid import addOpenIdPlugin
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
+from plone.portlets.interfaces import IPortletType
 from Products.CMFCore.utils import getToolByName
 from Products.PlonePAS.browser.info import PASInfoView
 from StringIO import StringIO
 from zope.component import getMultiAdapter
+from zope.component import getSiteManager
 from zope.component import queryUtility
+from zope.component.interfaces import IComponentRegistry
+
+import logging
+
+
+logger = logging.getLogger('plone.app.openid')
+PROFILE_ID = 'plone.app.openid:default'
 
 
 def hasOpenIdPlugin(portal):
@@ -61,3 +70,23 @@ def importVarious(context):
         activatePlugin(site, out, 'openid')
 
     addLoginPortlet(site, out)
+
+
+def registerPortletAddview(context):
+    portal = getToolByName(context, 'portal_url').getPortalObject()
+    sm = getSiteManager(portal)
+    if sm is None or not IComponentRegistry.providedBy(sm):
+        # plone.app.portlets.exportimport.portlets has this same check.
+        logger.info('Cannot register portlet addview - no site manager found.')
+        return
+    if queryUtility(IPortletType, name=''):
+        # For a few years we have registered our portlet with an empty string
+        # as add view.  This is wrong.
+        sm.unregisterUtility(provided=IPortletType, name='')
+        logger.info('Unregistered portlet type with empty addview.')
+    addview = 'portlets.OpenIDLogin'
+    if queryUtility(IPortletType, name=addview) is None:
+        # Apply our default portlets.xml.
+        context.runImportStepFromProfile(PROFILE_ID, 'portlets')
+        logger.info('Applied our portlets.xml to register portlet '
+                    'with correct addview.')

--- a/plone/app/openid/setuphandlers.py
+++ b/plone/app/openid/setuphandlers.py
@@ -47,6 +47,13 @@ def activatePlugin(portal, out, plugin):
     plugin.manage_activateInterfaces(activate)
 
 
+def removeOpenIdPlugin(portal):
+    if hasOpenIdPlugin(portal):
+        acl = getToolByName(portal, 'acl_users')
+        acl._delObject('openid')
+        logger.info('Removed openid plugin from acl_users.')
+
+
 def addLoginPortlet(portal, out):
     leftColumn = queryUtility(
         IPortletManager, name=u'plone.leftcolumn', context=portal)
@@ -56,6 +63,17 @@ def addLoginPortlet(portal, out):
         if u'openid-login' not in left:
             print >>out, 'Adding OpenID login portlet to the left column'  # noqa
             left[u'openid-login'] = LoginAssignment()
+
+
+def removeLoginPortlet(portal):
+    leftColumn = queryUtility(
+        IPortletManager, name=u'plone.leftcolumn', context=portal)
+    if leftColumn is not None:
+        left = getMultiAdapter((portal, leftColumn,),
+                               IPortletAssignmentMapping, context=portal)
+        if u'openid-login' in left:
+            del left[u'openid-login']
+            logger.info('Removed OpenID login portlet from the left column')
 
 
 def importVarious(context):
@@ -86,3 +104,9 @@ def registerPortletAddview(context):
         context.runImportStepFromProfile(PROFILE_ID, 'portlets')
         logger.info('Applied our portlets.xml to register portlet '
                     'with correct addview.')
+
+
+def uninstall(context):
+    portal = getToolByName(context, 'portal_url').getPortalObject()
+    removeOpenIdPlugin(portal)
+    removeLoginPortlet(portal)

--- a/plone/app/openid/setuphandlers.py
+++ b/plone/app/openid/setuphandlers.py
@@ -59,11 +59,7 @@ def addLoginPortlet(portal, out):
 
 
 def importVarious(context):
-    # Only run step if a flag file is present (e.g. not an extension profile)
-    if context.readDataFile('openid-pas.txt') is None:
-        return
-
-    site = context.getSite()
+    site = getToolByName(context, 'portal_url').getPortalObject()
     out = StringIO()
     if not hasOpenIdPlugin(site):
         createOpenIdPlugin(site, out)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'Products.CMFPlone',
         'Products.PlonePAS>=2.0.10dev',
         'Products.PluggableAuthService',
+        'Products.GenericSetup>=1.8.2',
         'Zope2',
     ],
     entry_points="""


### PR DESCRIPTION
Three things, see the separate commits.
This targets Plone 5.1. I have changed 5.0 to use new branch 2.1.x.
Technically the upgrade step is a fix that could be done on 5.0 as well. But it fixes something that has not bothered anyone for the past 6.5 years, since commit f1f08b6130297baf31cda86337ae151e6b38a430, so I think it is fine to do this on 5.1 only.