### PR TITLE
Removing unittest2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Removed dependency on unittest2
 
 2.2.1 (2016-08-18)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,14 +5,6 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
-
 Bug fixes:
 
 - Removed dependency on unittest2

--- a/plone/app/openid/tests/test_view.py
+++ b/plone/app/openid/tests/test_view.py
@@ -2,7 +2,7 @@
 from plone.app.openid.testing import PLONEAPPOPENID_INTEGRATION_TESTING
 from Products.PluggableAuthService.interfaces import plugins as plugin_ifaces
 
-import unittest2 as unittest
+import unittest
 
 
 class TestOpenIdView(unittest.TestCase):


### PR DESCRIPTION
As outlined on this bug report [https://github.com/plone/Products.CMFPlone/issues/1882](url), unittest2 is no longer needed  in packages targeted for python 2.7 or 3 only. I've tried to patch openid and tested the ad-on without any errors occurring.